### PR TITLE
Move rewrite to conventional location.

### DIFF
--- a/scalafix/input/src/main/scala/sbtfix/SbtOneZeroMigrationTest.scala
+++ b/scalafix/input/src/main/scala/sbtfix/SbtOneZeroMigrationTest.scala
@@ -1,5 +1,5 @@
 /*
-rewrite = "scala:sbtfix.SbtOneZeroMigration"
+rewrite = "scala:fix.Sbtfix_v1"
  */
 package sbtfix
 

--- a/scalafix/rewrites/src/main/scala/fix/Sbtfix_v1.scala
+++ b/scalafix/rewrites/src/main/scala/fix/Sbtfix_v1.scala
@@ -1,4 +1,4 @@
-package sbtfix
+package fix
 
 import scala.collection.immutable.Seq
 import scala.meta._
@@ -7,7 +7,7 @@ import scala.meta.tokens.Token.LeftParen
 import scala.meta.tokens.Token.RightParen
 import scalafix._
 
-case class SbtOneZeroMigration(brokenMirror: Mirror)
+case class Sbtfix_v1(brokenMirror: Mirror)
     extends SemanticRewrite(Sbthost.patchMirror(brokenMirror)) {
   val mirror = ImplicitMirror
   def rewrite(ctx: RewriteCtx): Patch = {


### PR DESCRIPTION
`scalafix scalacenter/sbtfix/v1` expands into `fix/Scalafix_v1.scala`.
It's possible to keep the original location if users write the full url
of the raw rewrite, `scalafix https://raw.githubusercontent.com/...`,
but I'd like to try and use this convention everywhere.